### PR TITLE
Fix package.json leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ build/Release # Compiled binary addons (http://nodejs.org/api/addons.html)
 
 dist
 lib
+src/package-info.json

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "karma-spec-reporter": "0.0.22",
     "karma-story-reporter": "^0.3.1",
     "karma-webpack": "^1.7.0",
-    "phantomjs": "^1.9.18",
+    "phantomjs": "^2.1.7",
     "pre-push": "^0.1.1",
     "webpack": "^1.12.13"
   },

--- a/package.json
+++ b/package.json
@@ -25,15 +25,16 @@
     "browserify"
   ],
   "scripts": {
-    "clean": "rm -rf dist/* && rm -rf lib/",
+    "clean": "rm -rf dist/* && rm -rf lib/ && rm -rf src/package-info.json",
     "minify:dev": "NODE_ENV=dev webpack --watch",
     "minify:prod": "NODE_ENV=prod webpack -p",
-    "compile:dev": "NODE_ENV=dev babel src --watch --out-dir lib",
-    "compile:prod": "NODE_ENV=prod babel src --out-dir lib",
+    "compile:dev": "NODE_ENV=dev npm run postversion && babel src --watch --out-dir lib",
+    "compile:prod": "NODE_ENV=prod npm run postversion && babel src --out-dir lib",
     "test:dev": "NODE_ENV=prod karma start test/karma.config.js --auto-watch",
     "test": "NODE_ENV=prod karma start test/karma.config.js --single-run",
     "build": "npm run clean && npm run compile:prod && npm run minify:prod",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "postversion": "node postversion.js"
   },
   "pre-commit": [
     "test"
@@ -78,6 +79,9 @@
     ]
   },
   "babel": {
-    "presets": ["es2015", "stage-2"]
+    "presets": [
+      "es2015",
+      "stage-2"
+    ]
   }
 }

--- a/postversion.js
+++ b/postversion.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const package = require('./package.json');
+
+fs.writeFileSync('./src/package-info.json', JSON.stringify({
+  name: package.name,
+  version: package.version,
+  repository: package.repository
+}));

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import easings from './easings'
 import RAF from 'animation-frame'
-import { name, version, repository } from './../package.json'
+import { name, version, repository } from './package-info.json'
 
 const rAF = new RAF()
 


### PR DESCRIPTION
Fixes #23 

As it's been trivial to create a small script to extract all necessary infos from `package.json`, I've opted for a dynamic solution. Of course, I'm happy to receive feedback.
I had to update the phantomjs dependency as it didn't run at all on my machine.